### PR TITLE
Only require needed submodules from 'unicode_utils'

### DIFF
--- a/lib/tty-table.rb
+++ b/lib/tty-table.rb
@@ -6,7 +6,7 @@ require 'necromancer'
 require 'verse'
 require 'tty-screen'
 require 'pastel'
-require 'unicode_utils'
+require 'unicode_utils/display_width'
 
 require 'tty/table/header'
 require 'tty/table/row'


### PR DESCRIPTION
Requiring 'unicode_utils' is pretty slow, and for short scripts it can have a noticeable impact on startup times. See lang/unicode_utils#6

As far as I can see, `tty-table` only uses `display_width`, and nothing else from the library. Simply changing `require 'unicode_utils'` to `require 'unicode_utils/display_width'` reduced the startup times for the scripts I tested on my linux laptop by roughly 100ms.