### PR TITLE
Issue #18: fix readme error for :each_row notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ In addition to specifying border characters you can force the table to render a 
 ```ruby
 table = TTY::Table.new ['header1', 'header2'], [['a1', 'a2'], ['b1', 'b2']]
 table.render do |renderer|
-  renderer.border.separator = :each_row
+  renderer.border.separator = TTY::Table::Border::EACH_ROW
 end
 # =>
 #  +-------+-------+


### PR DESCRIPTION
### Describe the change
Fix an error in the readme to make the example functional.

### Why are we doing this?
gem will get wider, easier use if documentation improves.

### Benefits
New users will be able to properly create tables following documentation.

### Drawbacks
None.

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[X] Documentation updated?
