### PR TITLE
Fix Issue #20

### DIFF
--- a/lib/tty/table/column_constraint.rb
+++ b/lib/tty/table/column_constraint.rb
@@ -141,7 +141,9 @@ module TTY
         ratio       = ((natural_width - renderer.width) / column_size.to_f).ceil
 
         widths = (0...column_size).reduce([]) do |lengths, col|
-          width = (renderer.column_widths[col] - ratio).clamp(minimum_width, renderer.width)
+          width = (renderer.column_widths[col] - ratio)
+          # basically ruby 2.4 Numeric#clamp
+          width = width < minimum_width ? minimum_width : (width > renderer.width ? renderer.width : width)
           lengths << width
         end
         distribute_extra_width(widths)

--- a/lib/tty/table/column_constraint.rb
+++ b/lib/tty/table/column_constraint.rb
@@ -143,7 +143,8 @@ module TTY
         widths = (0...column_size).reduce([]) do |lengths, col|
           width = (renderer.column_widths[col] - ratio)
           # basically ruby 2.4 Numeric#clamp
-          width = width < minimum_width ? minimum_width : (width > renderer.width ? renderer.width : width)
+          width = width < minimum_width ? minimum_width : width
+          width = width > renderer.width ? renderer.width : width
           lengths << width
         end
         distribute_extra_width(widths)

--- a/lib/tty/table/column_constraint.rb
+++ b/lib/tty/table/column_constraint.rb
@@ -141,7 +141,8 @@ module TTY
         ratio       = ((natural_width - renderer.width) / column_size.to_f).ceil
 
         widths = (0...column_size).reduce([]) do |lengths, col|
-          lengths + [renderer.column_widths[col] - ratio]
+          width = (renderer.column_widths[col] - ratio).clamp(minimum_width, renderer.width)
+          lengths << width
         end
         distribute_extra_width(widths)
       end

--- a/spec/unit/renderer/ascii/resizing_spec.rb
+++ b/spec/unit/renderer/ascii/resizing_spec.rb
@@ -99,12 +99,12 @@ RSpec.describe TTY::Table::Renderer::ASCII, 'resizing' do
 
       it 'resizes each column' do
         expect(renderer.render).to eql unindent(<<-EOS)
-         +---+---+-----+
-         |h… |h… |head3|
-         +---+---+-----+
-         |a… |aa2|aaa… |
-         |b1 |b2 |b3   |
-         +---+---+-----+
+         +----+----+---+
+         |he… |he… |h… |
+         +----+----+---+
+         |aaa1|aa2 |a… |
+         |b1  |b2  |b3 |
+         +----+----+---+
         EOS
       end
     end

--- a/spec/unit/renderer/basic/resizing_spec.rb
+++ b/spec/unit/renderer/basic/resizing_spec.rb
@@ -84,9 +84,9 @@ RSpec.describe TTY::Table::Renderer::Basic, 'resizing' do
 
       it 'resizes each column' do
         expect(renderer.render).to eql unindent(<<-EOS)
-          he…  he…  head3 
-          aaa1 aa2  aaaa… 
-          b1   b2   b3    
+          head1 he…  head3
+          aaa1  aa2  aaa… 
+          b1    b2   b3   
         EOS
       end
     end


### PR DESCRIPTION
### Describe the change
Partially fixes #20 - requires the strings patch here: piotrmurach/strings#8

### Why are we doing this?
Fixes the handling of too-small terminals, or very small supplied widths. previously the `width` was allowed to go negative which would make Strings#truncate throw an error. This fixes the negative numbers, and the strings patch fixes a column width of 1.

### Benefits
Covers an unhandled exception when using resize:true.

### Drawbacks
Tests were changed, as the output from the renderers is slightly different with the clamped width. 

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
