### PR TITLE
There could be part.to_a, but it is not an Enumerable, thus not responding to #map.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+/bin

--- a/lib/tty/table/indentation.rb
+++ b/lib/tty/table/indentation.rb
@@ -11,7 +11,7 @@ module TTY
       #
       # @api public
       def indent(part, indentation)
-        if part.respond_to?(:to_a)
+        if part.is_a?(Enumerable) && part.respond_to?(:to_a)
           part.map { |line| insert_indentation(line, indentation) }
         else
           insert_indentation(part, indentation)


### PR DESCRIPTION
Small improvement.
There could be `part.to_a`, but it is not an `Enumerable`, thus not responding to `#map`.
I used TTY::Table for output in tests. But I have defined `String.to_a` in my prog.
And it crashes with `NoMethodError: undefined method `map' for "│a1   │b1    │c1  │":String`

[X] Tests written & passing locally?
[X] Code style checked?

