### PR TITLE
Allow table rotation and resizing to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Rendering of **TTY-Table** includes numerous customization options:
 * `:indent` - indentation applied to rendered table, by default 0
 * `:multiline` - when `true` will wrap text at new line or column width, when `false` will escape special characters
 * `:padding` - array of integers to set table fields padding. Defaults to `[0,0,0,0]`.
-* `:resize` - when `true` will expand/shrink table column sizes to match the terminal width, otherwise when `false` will rotate table vertically. Defaults to `false`.
+* `:resize` - when `true` will expand/shrink table column sizes to match the terminal width, when `false` will rotate table vertically, otherwise when `nil` the table will not be altered. Defaults to `false`.
 * `:width` - constrains the table total width. Defaults to value automatically calculated based on the content and terminal size.
 
 The `render` method can accept as a second argument the above options either as hash value:

--- a/lib/tty/table/column_constraint.rb
+++ b/lib/tty/table/column_constraint.rb
@@ -87,21 +87,18 @@ module TTY
       def enforce
         assert_minimum_width
         padding = renderer.padding
+        width_bool = natural_width <= renderer.width
 
-        if natural_width <= renderer.width
-          if renderer.resize
-            expand_column_widths
-          else
-            renderer.column_widths.map do |width|
-              padding.left + width + padding.right
-            end
+        if width_bool && renderer.resize
+          expand_column_widths
+        elsif width_bool || renderer.resize.nil?
+          renderer.column_widths.map do |width|
+            padding.left + width + padding.right
           end
+        elsif renderer.resize
+          shrink
         else
-          if renderer.resize
-            shrink
-          else
-            rotate
-          end
+          rotate
         end
       end
 

--- a/spec/unit/column_constraint/enforce_spec.rb
+++ b/spec/unit/column_constraint/enforce_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TTY::Table::ColumnConstraint, '#enforce' do
       end
     end
 
-    context 'without resize' do
+    context 'without resize (false)' do
       let(:options) { { width: 8, resize: false }}
 
       it 'changes table orientation to vertical' do
@@ -52,6 +52,17 @@ RSpec.describe TTY::Table::ColumnConstraint, '#enforce' do
         column_widths = columns.enforce
         expect(column_widths).to eq([2,2])
         expect(table.orientation.name).to eql(:vertical)
+      end
+    end
+
+    context 'without resize (nil)' do
+      let(:options) { { width: 8, resize: nil }}
+
+      it 'ignores the maximum width constraint' do
+        expect(columns).not_to receive(:shrink)
+        column_widths = columns.enforce
+        expect(column_widths).to eql([2,2,2,2])
+        expect(table.orientation.name).to eql(:horizontal)
       end
     end
   end


### PR DESCRIPTION
I've been having a couple of issues with the `resize` feature and external pagers. When rendering an extra large table with `less`, one of the two happens:

1. When `resize: false` the table is rotated, or
2. When `resize: true` the table is shrunk.

This occurs because the terminal width is not "technically increased" by the pager. However in practice the width is infinitely large. Instead it would be useful if the resizing and rotation feature can be disabled entirely.

I have updated `ColumnConstraint` to support a `resize: nil` option which disables the terminal width check. This causes the table to be rendered according to its nature_width. Then a pager can handle the extra wide tables.

Both the `resize: true` and `resize: false` options are unaffected by this change add the default is still `false`.