### PR TITLE
Fix for piotrmurach/issues/35

### DIFF
--- a/lib/tty/table/orientation/horizontal.rb
+++ b/lib/tty/table/orientation/horizontal.rb
@@ -24,23 +24,21 @@ module TTY
         # @api public
         def slice(table)
           head, body, array_h, array_b = 4.times.map { [] }
-          index         = 0
           first_column  = 0
           second_column = 1
 
           (0...table.original_columns * table.original_rows).each do |col_index|
-            row      = table.rows[index]
+            row      = table.rows[col_index]
             array_h += [row[first_column]]
             array_b += [row[second_column]]
 
-            if col_index % table.original_columns == 2
+            if (col_index + 1) % table.original_columns == 0
               head << array_h
               body << array_b
               array_h, array_b = [], []
             end
-            index += 1
           end
-          [head, body]
+          [head.uniq, body]
         end
       end # Horizontal
     end # Orientation

--- a/lib/tty/table/orientation/vertical.rb
+++ b/lib/tty/table/orientation/vertical.rb
@@ -26,7 +26,7 @@ module TTY
           header    = table.header
           rows_size = table.rows_size
 
-          head = header ? header : (0..rows_size).map { |n| (n + 1).to_s }
+          head = header ? header : (1..table.columns_count).map(&:to_s)
 
           (0...rows_size).reduce([]) do |array, index|
             array + head.zip(table.rows[index]).map { |row| table.to_row(row) }

--- a/spec/unit/rotate_spec.rb
+++ b/spec/unit/rotate_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe TTY::Table, '#rotate' do
-  let(:header) { ['h1', 'h2', 'h3'] }
-  let(:rows) { [['a1', 'a2', 'a3'], ['b1', 'b2', 'b3']] }
+  let(:header) { ['h1', 'h2', 'h3', 'h4', 'h5'] }
+  let(:rows) { [['a1', 'a2', 'a3', 'a4', 'a5'], ['b1', 'b2', 'b3', 'b4', 'b5']] }
 
   subject(:table) { described_class.new(header, rows) }
 
@@ -34,9 +34,13 @@ RSpec.describe TTY::Table, '#rotate' do
         ['1', 'a1'],
         ['2', 'a2'],
         ['3', 'a3'],
+        ['4', 'a4'],
+        ['5', 'a5'],
         ['1', 'b1'],
         ['2', 'b2'],
         ['3', 'b3'],
+        ['4', 'b4'],
+        ['5', 'b5']
       ]
       expect(table.header).to be_nil
     end
@@ -49,11 +53,11 @@ RSpec.describe TTY::Table, '#rotate' do
       expect(table.header).to eql header
     end
 
-    it 'roates the output' do
-      expect(table.to_s).to eq("a1 a2 a3\nb1 b2 b3")
+    it 'rotates the output' do
+      expect(table.to_s).to eq("a1 a2 a3 a4 a5\nb1 b2 b3 b4 b5")
       table.orientation = :vertical
       table.rotate
-      expect(table.to_s).to eq("1 a1\n2 a2\n3 a3\n1 b1\n2 b2\n3 b3")
+      expect(table.to_s).to eq("1 a1\n2 a2\n3 a3\n4 a4\n5 a5\n1 b1\n2 b2\n3 b3\n4 b4\n5 b5")
     end
   end
 
@@ -64,9 +68,13 @@ RSpec.describe TTY::Table, '#rotate' do
         ['h1', 'a1'],
         ['h2', 'a2'],
         ['h3', 'a3'],
+        ['h4', 'a4'],
+        ['h5', 'a5'],
         ['h1', 'b1'],
         ['h2', 'b2'],
         ['h3', 'b3'],
+        ['h4', 'b4'],
+        ['h5', 'b5']
       ]
       expect(table.header).to be_empty
     end


### PR DESCRIPTION
### Describe the change
It fixes an issue that happens by rotating to vertical and back providing no header described at piotrmurach/issues/35.

### Why are we doing this?
It was failing when the table size exceeds the currently set width and it defaults to vertical orientation.

### Benefits
The gem will behave as expected when rotated to vertical and again when back to horizontal.

### Drawbacks
None that I can foresee, but does not hurt to have a look before. Could be good to improve all specs to have further columns and different number of columns vs rows both including versions with more columns than rows and more rows than columns to check if further similar issues are found across the library.

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[] Documentation updated?
