### PR TITLE
Fix indent bug for tables without headers (issue piotrmurach/tty-table/issues/45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### Fixed
+* Fix indentation of tables with no headers by Roger Marlow(@rogermarlow)
+
 ## [v0.12.0] - 2020-09-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change log
 
 ### Fixed
-* Fix indentation of tables with no headers by Roger Marlow(@rogermarlow)
+* Fix indentation of tables without headers by Roger Marlow(@rogermarlow)
 
 ## [v0.12.0] - 2020-09-20
 

--- a/lib/tty/table/indentation.rb
+++ b/lib/tty/table/indentation.rb
@@ -30,7 +30,7 @@ module TTY
       #
       # @api public
       def insert_indentation(line, indentation)
-        line ? " " * indentation + line.to_s : ""
+        line ? " " * indentation + line.to_s : line
       end
       module_function :insert_indentation
     end # Indentation

--- a/lib/tty/table/renderer/basic.rb
+++ b/lib/tty/table/renderer/basic.rb
@@ -199,7 +199,6 @@ module TTY
             operations.add(*op)
           end
           operations.apply_to(table, *select_operations)
-
           render_data.compact.join("\n")
         end
 

--- a/lib/tty/table/renderer/basic.rb
+++ b/lib/tty/table/renderer/basic.rb
@@ -267,7 +267,9 @@ module TTY
         # @api private
         def render_header(row, data_border)
           top_line = data_border.top_line
-          return Indentation.indent(top_line, @indent) unless row.is_a?(TTY::Table::Header)
+          unless row.is_a?(TTY::Table::Header)
+            return Indentation.indent(top_line, @indent)
+          end
           header = [top_line, data_border.row_line(row)]
           if !border.separator || border.separator?(0)
             header << data_border.middle_line

--- a/lib/tty/table/renderer/basic.rb
+++ b/lib/tty/table/renderer/basic.rb
@@ -267,7 +267,7 @@ module TTY
         # @api private
         def render_header(row, data_border)
           top_line = data_border.top_line
-          return top_line unless row.is_a?(TTY::Table::Header)
+          return Indentation.indent(top_line, @indent) unless row.is_a?(TTY::Table::Header)
           header = [top_line, data_border.row_line(row)]
           if !border.separator || border.separator?(0)
             header << data_border.middle_line

--- a/spec/unit/renderer/ascii/indentation_spec.rb
+++ b/spec/unit/renderer/ascii/indentation_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TTY::Table::Renderer::ASCII, 'indentation' do
 end
 
 RSpec.describe TTY::Table::Renderer::ASCII, "indentation without headers" do
-  it "indents top border correctly" do
+  it "does not regress on issue 45" do
     table = TTY::Table.new
     table << %w(a1 a2 a3)
     table << %w(b1 b2 b3)

--- a/spec/unit/renderer/ascii/indentation_spec.rb
+++ b/spec/unit/renderer/ascii/indentation_spec.rb
@@ -37,3 +37,17 @@ RSpec.describe TTY::Table::Renderer::ASCII, 'indentation' do
     end
   end
 end
+
+RSpec.describe TTY::Table::Renderer::ASCII, 'indentation without headers' do
+  it "indents top border correctly" do
+    table = TTY::Table.new
+    table << ["a1","a2","a3"]
+    table << ["b1","b2","b3"]
+    expect(table.render(:ascii, indent: 3)).to eql([
+      "   +--+--+--+",
+      "   |a1|a2|a3|",
+      "   |b1|b2|b3|",
+      "   +--+--+--+"
+    ].join("\n"))
+  end
+end

--- a/spec/unit/renderer/ascii/indentation_spec.rb
+++ b/spec/unit/renderer/ascii/indentation_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe TTY::Table::Renderer::ASCII, 'indentation' do
   end
 end
 
-RSpec.describe TTY::Table::Renderer::ASCII, 'indentation without headers' do
+RSpec.describe TTY::Table::Renderer::ASCII, "indentation without headers" do
   it "indents top border correctly" do
     table = TTY::Table.new
     table << %w(a1 a2 a3)

--- a/spec/unit/renderer/ascii/indentation_spec.rb
+++ b/spec/unit/renderer/ascii/indentation_spec.rb
@@ -41,8 +41,8 @@ end
 RSpec.describe TTY::Table::Renderer::ASCII, 'indentation without headers' do
   it "indents top border correctly" do
     table = TTY::Table.new
-    table << ["a1","a2","a3"]
-    table << ["b1","b2","b3"]
+    table << %w(a1 a2 a3)
+    table << %w(b1 b2 b3)
     expect(table.render(:ascii, indent: 3)).to eql([
       "   +--+--+--+",
       "   |a1|a2|a3|",


### PR DESCRIPTION
### Describe the change
There is a bug rendering tables without headers with an indent. The top border is not indented.

### Why are we doing this?
Bug fix.

### Benefits
Bug fix.

### Drawbacks
None.

Here is come code that demonstrates the problem:

```ruby
require 'tty-table'

ok = TTY::Table.new(header: ["Home","H","A","Away"])
ok << ["team1",1,2,"team2"]
ok << ["team3",0,1,"team4"]

puts ok.render(:unicode, indent: 12)

broken = TTY::Table.new
broken << ["team1",1,2,"team2"]
broken << ["team3",0,1,"team4"]

puts broken.render(:unicode, indent: 12)

            ┌─────┬─┬─┬─────┐
            │Home │H│A│Away │
            ├─────┼─┼─┼─────┤
            │team1│1│2│team2│
            │team3│0│1│team4│
            └─────┴─┴─┴─────┘
┌─────┬─┬─┬─────┐
            │team1│1│2│team2│
            │team3│0│1│team4│
            └─────┴─┴─┴─────┘
```



### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [X] Code style checked?
- [ ] Rebased with `master` branch?
- [X] Documentation updated?
- [X] Changelog updated?
